### PR TITLE
Fix wrong style reset

### DIFF
--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -102,7 +102,8 @@ module.exports = function documentScreenshot(fileName, options) {
                  * remove scrollbars
                  */
                 // reset height in case we're changing viewports
-                document.documentElement.style.height = 'auto';
+                document.documentElement.style.height = '';
+                document.documentElement.style.overflow = '';
                 document.documentElement.style.height = document.documentElement.scrollHeight + 'px';
                 document.documentElement.style.overflow = 'hidden';
             })


### PR DESCRIPTION
JavaScript styles should be reset by assigning an empty string on the property. Thus styles defined in stylesheet will be used again. This commit fixes an issue when the documentElement has height: 100% applied. In this case, setting height: auto may cause a collapsed container.
